### PR TITLE
Replace deprecated method for mesh load check

### DIFF
--- a/perception_msgs_rendering/src/rendering/object_state/object_state.cpp
+++ b/perception_msgs_rendering/src/rendering/object_state/object_state.cpp
@@ -276,7 +276,8 @@ void ObjectState::setObjectStateVizDefault(const perception_msgs::msg::ObjectSta
         break;
     }
 
-    if (!mesh.isNull())
+    // Check if mesh was loaded successfully (nullptr if loading failed)
+    if (mesh)
     {
       // compute mesh scaling factors to fixed height
       Ogre::Vector3 mesh_dims = mesh->getBounds().getSize();


### PR DESCRIPTION
This pull request replaces the deprecated `isNull()` method in `if (!mesh.isNull())` with a validity check using `if (mesh)`. This relies on OGRE’s `SharedPtr` `operator bool()` to verify whether the mesh pointer is non-null.