### PR TITLE
Fix object list predictions and add support for kilted

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [noetic, humble, jazzy, rolling]
+        ROS_DISTRO: [noetic, humble, jazzy, kilted, rolling]
         ROS_REPO: [testing, main]
     steps:
       - uses: actions/checkout@v4

--- a/perception_msgs_rendering/CMakeLists.txt
+++ b/perception_msgs_rendering/CMakeLists.txt
@@ -3,6 +3,7 @@ project(perception_msgs_rendering)
 
 find_package(ros_environment REQUIRED QUIET)
 set(ROS_VERSION $ENV{ROS_VERSION})
+add_compile_definitions(ROS_DISTRO_$ENV{ROS_DISTRO})
 
 # === ROS2 (AMENT) =============================================================
 if(${ROS_VERSION} EQUAL 2)

--- a/perception_msgs_rendering/CMakeLists.txt
+++ b/perception_msgs_rendering/CMakeLists.txt
@@ -3,7 +3,9 @@ project(perception_msgs_rendering)
 
 find_package(ros_environment REQUIRED QUIET)
 set(ROS_VERSION $ENV{ROS_VERSION})
-add_compile_definitions(ROS_DISTRO_$ENV{ROS_DISTRO})
+set(ROS_DISTRO $ENV{ROS_DISTRO})
+
+add_compile_definitions(ROS_DISTRO_${ROS_DISTRO})
 
 # === ROS2 (AMENT) =============================================================
 if(${ROS_VERSION} EQUAL 2)
@@ -25,6 +27,12 @@ if(${ROS_VERSION} EQUAL 2)
   find_package(rviz_rendering REQUIRED)
   find_package(resource_retriever REQUIRED)
   find_package(tf2_geometry_msgs REQUIRED)
+
+  if(NOT ROS_DISTRO STREQUAL "noetic"
+      AND NOT ROS_DISTRO STREQUAL "humble"
+      AND NOT ROS_DISTRO STREQUAL "jazzy")
+    find_package(resource_retriever REQUIRED)
+  endif()
 
   # Adds shallow folders containing ogre_media such as meshes and scripts to Rviz
   # so that they can be found at runtime. Requires rviz_rendering.
@@ -60,6 +68,11 @@ if(${ROS_VERSION} EQUAL 2)
     resource_retriever
     tf2_geometry_msgs
   )
+  if(NOT ROS_DISTRO STREQUAL "noetic"
+      AND NOT ROS_DISTRO STREQUAL "humble"
+      AND NOT ROS_DISTRO STREQUAL "jazzy")
+    ament_target_dependencies(${PROJECT_NAME} PUBLIC resource_retriever)
+  endif()
 
   ament_export_dependencies(
     geometry_msgs

--- a/perception_msgs_rendering/CMakeLists.txt
+++ b/perception_msgs_rendering/CMakeLists.txt
@@ -25,7 +25,6 @@ if(${ROS_VERSION} EQUAL 2)
   find_package(rviz_common REQUIRED)
   find_package(rviz_ogre_vendor REQUIRED)
   find_package(rviz_rendering REQUIRED)
-  find_package(resource_retriever REQUIRED)
   find_package(tf2_geometry_msgs REQUIRED)
 
   if(NOT ROS_DISTRO STREQUAL "noetic"

--- a/perception_msgs_rendering/CMakeLists.txt
+++ b/perception_msgs_rendering/CMakeLists.txt
@@ -65,7 +65,6 @@ if(${ROS_VERSION} EQUAL 2)
     perception_msgs_utils
     rviz_common
     rviz_rendering
-    resource_retriever
     tf2_geometry_msgs
   )
   if(NOT ROS_DISTRO STREQUAL "noetic"

--- a/perception_msgs_rendering/CMakeLists.txt
+++ b/perception_msgs_rendering/CMakeLists.txt
@@ -22,6 +22,7 @@ if(${ROS_VERSION} EQUAL 2)
   find_package(rviz_common REQUIRED)
   find_package(rviz_ogre_vendor REQUIRED)
   find_package(rviz_rendering REQUIRED)
+  find_package(resource_retriever REQUIRED)
   find_package(tf2_geometry_msgs REQUIRED)
 
   # Adds shallow folders containing ogre_media such as meshes and scripts to Rviz
@@ -55,6 +56,7 @@ if(${ROS_VERSION} EQUAL 2)
     perception_msgs_utils
     rviz_common
     rviz_rendering
+    resource_retriever
     tf2_geometry_msgs
   )
 

--- a/perception_msgs_rendering/src/rendering/object_state/object_state.cpp
+++ b/perception_msgs_rendering/src/rendering/object_state/object_state.cpp
@@ -416,6 +416,7 @@ void ObjectState::setObjectPredictionsVizDefault(
     billboard_line_prediction->setColor(line_color.r, line_color.g, line_color.b, line_color.a);
     float line_width = prediction_line_width_;
     billboard_line_prediction->setLineWidth(line_width);
+    billboard_line_prediction->setMaxPointsPerLine(states.size());
     auto base_state = perception_msgs::object_access::getPose(object_state_);
     tf2::Transform base_state_tf;
     tf2::fromMsg(base_state, base_state_tf);

--- a/perception_msgs_rendering/src/rendering/object_state/object_state.cpp
+++ b/perception_msgs_rendering/src/rendering/object_state/object_state.cpp
@@ -243,35 +243,36 @@ void ObjectState::setObjectStateVizDefault(const perception_msgs::msg::ObjectSta
     //load mesh to render based on classification
     Ogre::Entity* entity;
     Ogre::MeshPtr mesh;
+    resource_retriever::Retriever* retriever;
 
     using namespace perception_msgs::msg;
     switch (classification_.type) {
       case ObjectClassification::CAR:
-        mesh = rviz_rendering::loadMeshFromResource("package://perception_msgs_rendering/meshes/car.stl");
+        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/car.stl");
         material = "CarMaterial";
         break;
       case ObjectClassification::TRUCK:
-        mesh = rviz_rendering::loadMeshFromResource("package://perception_msgs_rendering/meshes/truck.stl");
+        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/truck.stl");
         material = "TruckMaterial";
         break;
       case ObjectClassification::BUS:
-        mesh = rviz_rendering::loadMeshFromResource("package://perception_msgs_rendering/meshes/bus.stl");
+        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/bus.stl");
         material = "BusMaterial";
         break;
       case ObjectClassification::BICYCLE:
-        mesh = rviz_rendering::loadMeshFromResource("package://perception_msgs_rendering/meshes/bicycle.stl");
+        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/bicycle.stl");
         material = "BicycleMaterial";
         break;
       case ObjectClassification::MOTORBIKE:
-        mesh = rviz_rendering::loadMeshFromResource("package://perception_msgs_rendering/meshes/motorbike.stl");
+        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/motorbike.stl");
         material = "MotorbikeMaterial";
         break;
       case ObjectClassification::PEDESTRIAN:
-        mesh = rviz_rendering::loadMeshFromResource("package://perception_msgs_rendering/meshes/pedestrian.stl");
+        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/pedestrian.stl");
         material = "PedestrianMaterial";
         break;
       default:
-        mesh = rviz_rendering::loadMeshFromResource("package://perception_msgs_rendering/meshes/car.stl");
+        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/car.stl");
         material = "CarMaterial";
         break;
     }

--- a/perception_msgs_rendering/src/rendering/object_state/object_state.cpp
+++ b/perception_msgs_rendering/src/rendering/object_state/object_state.cpp
@@ -243,39 +243,47 @@ void ObjectState::setObjectStateVizDefault(const perception_msgs::msg::ObjectSta
     //load mesh to render based on classification
     Ogre::Entity* entity;
     Ogre::MeshPtr mesh;
-    resource_retriever::Retriever* retriever;
+
+    std::string package;
 
     using namespace perception_msgs::msg;
     switch (classification_.type) {
       case ObjectClassification::CAR:
-        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/car.stl");
+        package = "package://perception_msgs_rendering/meshes/car.stl";
         material = "CarMaterial";
         break;
       case ObjectClassification::TRUCK:
-        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/truck.stl");
+        package = "package://perception_msgs_rendering/meshes/truck.stl";
         material = "TruckMaterial";
         break;
       case ObjectClassification::BUS:
-        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/bus.stl");
+        package = "package://perception_msgs_rendering/meshes/bus.stl";
         material = "BusMaterial";
         break;
       case ObjectClassification::BICYCLE:
-        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/bicycle.stl");
+        package = "package://perception_msgs_rendering/meshes/bicycle.stl";
         material = "BicycleMaterial";
         break;
       case ObjectClassification::MOTORBIKE:
-        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/motorbike.stl");
+        package = "package://perception_msgs_rendering/meshes/motorbike.stl";
         material = "MotorbikeMaterial";
         break;
       case ObjectClassification::PEDESTRIAN:
-        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/pedestrian.stl");
+        package = "package://perception_msgs_rendering/meshes/pedestrian.stl";
         material = "PedestrianMaterial";
         break;
       default:
-        mesh = rviz_rendering::loadMeshFromResource(retriever, "package://perception_msgs_rendering/meshes/car.stl");
+        package = "package://perception_msgs_rendering/meshes/car.stl";
         material = "CarMaterial";
         break;
     }
+
+  #if defined(ROS_DISTRO_noetic) || defined(ROS_DISTRO_humble) || defined(ROS_DISTRO_jazzy)
+    mesh = rviz_rendering::loadMeshFromResource(package);
+  #else
+    resource_retriever::Retriever* retriever;
+    mesh = rviz_rendering::loadMeshFromResource(retriever, package);
+  #endif  
 
     // Check if mesh was loaded successfully (nullptr if loading failed)
     if (mesh)


### PR DESCRIPTION
- Set billboard line size to number of state predictions
- Support kilted
  - function header of [loadMeshFromResource](https://github.com/ros2/rviz/blob/jazzy/rviz_rendering/include/rviz_rendering/mesh_loader.hpp#L42C15-L42C35) changed in [ROS 2 kilted](https://github.com/ros2/rviz/blob/kilted/rviz_rendering/include/rviz_rendering/mesh_loader.hpp#L46).
  - add compiler flags to allow if/else in `perception_msgs_rendering` package