### PR TITLE
Improve angle wrapping

### DIFF
--- a/perception_msgs_utils/include/perception_msgs_utils/impl/state_setters.h
+++ b/perception_msgs_utils/include/perception_msgs_utils/impl/state_setters.h
@@ -237,8 +237,8 @@ namespace object_access {
   inline void setRoll(ObjectState& state, const double val, const bool reset_covariance = true) {
     sanityCheckContinuousState(state);
     double capped_val = val;
-    while (capped_val > M_PI) capped_val -= 2 * M_PI;
-    while (capped_val < -M_PI) capped_val += 2 * M_PI;
+    capped_val -= 2.f * M_PI * std::floor((capped_val + M_PI) * (M_1_PI * 0.5f));
+    if (capped_val <= -M_PI) capped_val += 2 * M_PI;
     const int idx = indexRoll(state.model_id);
     state.continuous_state[idx] = capped_val;
     if (reset_covariance) setContinuousStateCovarianceToUnknownAt(state, idx, idx);
@@ -294,8 +294,8 @@ namespace object_access {
   inline void setPitch(ObjectState& state, const double val, const bool reset_covariance = true) {
     sanityCheckContinuousState(state);
     double capped_val = val;
-    while (capped_val > M_PI) capped_val -= 2 * M_PI;
-    while (capped_val < -M_PI) capped_val += 2 * M_PI;
+    capped_val -= 2.f * M_PI * std::floor((capped_val + M_PI) * (M_1_PI * 0.5f));
+    if (capped_val <= -M_PI) capped_val += 2 * M_PI;
     const int idx = indexPitch(state.model_id);
     state.continuous_state[idx] = capped_val;
     if (reset_covariance) setContinuousStateCovarianceToUnknownAt(state, idx, idx);
@@ -351,8 +351,8 @@ namespace object_access {
   inline void setYaw(ObjectState& state, const double val, const bool reset_covariance = true) {
     sanityCheckContinuousState(state);
     double capped_val = val;
-    while (capped_val > M_PI) capped_val -= 2 * M_PI;
-    while (capped_val < -M_PI) capped_val += 2 * M_PI;
+    capped_val -= 2.f * M_PI * std::floor((capped_val + M_PI) * (M_1_PI * 0.5f));
+    if (capped_val <= -M_PI) capped_val += 2 * M_PI;
     const int idx = indexYaw(state.model_id);
     state.continuous_state[idx] = capped_val;
     if (reset_covariance) setContinuousStateCovarianceToUnknownAt(state, idx, idx);

--- a/perception_msgs_utils/include/perception_msgs_utils/impl/state_setters.h
+++ b/perception_msgs_utils/include/perception_msgs_utils/impl/state_setters.h
@@ -237,7 +237,7 @@ namespace object_access {
   inline void setRoll(ObjectState& state, const double val, const bool reset_covariance = true) {
     sanityCheckContinuousState(state);
     double capped_val = val;
-    capped_val -= 2.f * M_PI * std::floor((capped_val + M_PI) * (M_1_PI * 0.5f));
+    capped_val -= 2.0 * M_PI * std::floor((capped_val + M_PI) * (M_1_PI * 0.5));
     if (capped_val <= -M_PI) capped_val += 2 * M_PI;
     const int idx = indexRoll(state.model_id);
     state.continuous_state[idx] = capped_val;
@@ -294,7 +294,7 @@ namespace object_access {
   inline void setPitch(ObjectState& state, const double val, const bool reset_covariance = true) {
     sanityCheckContinuousState(state);
     double capped_val = val;
-    capped_val -= 2.f * M_PI * std::floor((capped_val + M_PI) * (M_1_PI * 0.5f));
+    capped_val -= 2.0 * M_PI * std::floor((capped_val + M_PI) * (M_1_PI * 0.5));
     if (capped_val <= -M_PI) capped_val += 2 * M_PI;
     const int idx = indexPitch(state.model_id);
     state.continuous_state[idx] = capped_val;
@@ -351,7 +351,7 @@ namespace object_access {
   inline void setYaw(ObjectState& state, const double val, const bool reset_covariance = true) {
     sanityCheckContinuousState(state);
     double capped_val = val;
-    capped_val -= 2.f * M_PI * std::floor((capped_val + M_PI) * (M_1_PI * 0.5f));
+    capped_val -= 2.0 * M_PI * std::floor((capped_val + M_PI) * (M_1_PI * 0.5));
     if (capped_val <= -M_PI) capped_val += 2 * M_PI;
     const int idx = indexYaw(state.model_id);
     state.continuous_state[idx] = capped_val;


### PR DESCRIPTION
Angle wrapping currently failed for verly large values because the loop turns into an infinite loop due to rounding errors.
Of course, noone should input huge angles, but if they accidentally do so, the error is insanely hard to find.

This replaces the old loop with a single operation and an additional line correcting possible rounding errors