### PR TITLE
Add turn indicator information to state models

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ROS_DISTRO: [noetic, humble, jazzy, kilted, rolling]
-        ROS_REPO: [testing, main]
+        ROS_REPO: [main]
     steps:
       - uses: actions/checkout@v4
       - uses: ros-industrial/industrial_ci@master

--- a/perception_msgs/msg/EGO.msg
+++ b/perception_msgs/msg/EGO.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=1
 uint8 CONTINUOUS_STATE_SIZE=13
-uint8 DISCRETE_STATE_SIZE=2
+uint8 DISCRETE_STATE_SIZE=4
 
-#   The EGO state model (N=13 & M=2) has the following entries
+#   The EGO state model (N=13 & M=4) has the following entries
 #   continuous_state:
 uint8 X=0                           # x position of reference point in header frame [m]
 uint8 Y=1                           # y position of reference point in header frame [m]
@@ -23,11 +23,17 @@ uint8 STEERING_ANGLE_RATE_ACK=12    # steering angle rate according to ackermann
 #   discrete_state:
 uint8 STANDSTILL=0                  # flag indicating standstill of the vehicle
 uint8 TURN_INDICATOR=1              # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
+uint8 BRAKE_LIGHT=2                 # brake light state (0=unknown, 1=off, 2=on)
+uint8 REVERSE_LIGHT=3               # reverse light state (0=unknown, 1=off, 2=on)
 
 # discrete state enums
-uint8 TURN_INDICATOR_UNKNOWN=0
-uint8 TURN_INDICATOR_OFF=1
-uint8 TURN_INDICATOR_LEFT=2
-uint8 TURN_INDICATOR_RIGHT=3
-uint8 TURN_INDICATOR_HAZARD=4
+int64 TURN_INDICATOR_UNKNOWN=0
+int64 TURN_INDICATOR_OFF=1
+int64 TURN_INDICATOR_LEFT=2
+int64 TURN_INDICATOR_RIGHT=3
+int64 TURN_INDICATOR_HAZARD=4
+
+int64 LIGHT_UNKNOWN=0
+int64 LIGHT_OFF=1
+int64 LIGHT_ON=2
 ###########################################################################################################################################################

--- a/perception_msgs/msg/EGO.msg
+++ b/perception_msgs/msg/EGO.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=1
 uint8 CONTINUOUS_STATE_SIZE=13
-uint8 DISCRETE_STATE_SIZE=1
+uint8 DISCRETE_STATE_SIZE=2
 
-#   The EGO state model (N=13 & M=1) has the following entries
+#   The EGO state model (N=13 & M=2) has the following entries
 #   continuous_state:
 uint8 X=0                           # x position of reference point in header frame [m]
 uint8 Y=1                           # y position of reference point in header frame [m]
@@ -22,4 +22,12 @@ uint8 STEERING_ANGLE_ACK=11         # steering angle according to ackermann mode
 uint8 STEERING_ANGLE_RATE_ACK=12    # steering angle rate according to ackermann model [rad/s]
 #   discrete_state:
 uint8 STANDSTILL=0                  # flag indicating standstill of the vehicle
+uint8 TURN_INDICATOR=1              # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
+
+# discrete state enums
+uint8 TURN_INDICATOR_UNKNOWN=0
+uint8 TURN_INDICATOR_OFF=1
+uint8 TURN_INDICATOR_LEFT=2
+uint8 TURN_INDICATOR_RIGHT=3
+uint8 TURN_INDICATOR_HAZARD=4
 ###########################################################################################################################################################

--- a/perception_msgs/msg/EGORWS.msg
+++ b/perception_msgs/msg/EGORWS.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=2
 uint8 CONTINUOUS_STATE_SIZE=13
-uint8 DISCRETE_STATE_SIZE=1
+uint8 DISCRETE_STATE_SIZE=2
 
-#   The EGORWS state model (N=13 & M=1) has the following entries
+#   The EGORWS state model (N=13 & M=2) has the following entries
 #   continuous_state:
 uint8 X=0                           # x position of reference point in header frame [m]
 uint8 Y=1                           # y position of reference point in header frame [m]
@@ -22,4 +22,12 @@ uint8 STEERING_ANGLE_FRONT=11       # steering angle of front wheels [rad]
 uint8 STEERING_ANGLE_REAR=12        # steering angle of rear wheels [rad]
 #   discrete_state:
 uint8 STANDSTILL=0                  # flag indicating standstill of the vehicle
+uint8 TURN_INDICATOR=1              # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
+
+# discrete state enums
+uint8 TURN_INDICATOR_UNKNOWN=0
+uint8 TURN_INDICATOR_OFF=1
+uint8 TURN_INDICATOR_LEFT=2
+uint8 TURN_INDICATOR_RIGHT=3
+uint8 TURN_INDICATOR_HAZARD=4
 ###########################################################################################################################################################

--- a/perception_msgs/msg/EGORWS.msg
+++ b/perception_msgs/msg/EGORWS.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=2
 uint8 CONTINUOUS_STATE_SIZE=13
-uint8 DISCRETE_STATE_SIZE=2
+uint8 DISCRETE_STATE_SIZE=4
 
-#   The EGORWS state model (N=13 & M=2) has the following entries
+#   The EGORWS state model (N=13 & M=4) has the following entries
 #   continuous_state:
 uint8 X=0                           # x position of reference point in header frame [m]
 uint8 Y=1                           # y position of reference point in header frame [m]
@@ -23,11 +23,17 @@ uint8 STEERING_ANGLE_REAR=12        # steering angle of rear wheels [rad]
 #   discrete_state:
 uint8 STANDSTILL=0                  # flag indicating standstill of the vehicle
 uint8 TURN_INDICATOR=1              # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
+uint8 BRAKE_LIGHT=2                 # brake light state (0=unknown, 1=off, 2=on)
+uint8 REVERSE_LIGHT=3               # reverse light state (0=unknown, 1=off, 2=on)
 
 # discrete state enums
-uint8 TURN_INDICATOR_UNKNOWN=0
-uint8 TURN_INDICATOR_OFF=1
-uint8 TURN_INDICATOR_LEFT=2
-uint8 TURN_INDICATOR_RIGHT=3
-uint8 TURN_INDICATOR_HAZARD=4
+int64 TURN_INDICATOR_UNKNOWN=0
+int64 TURN_INDICATOR_OFF=1
+int64 TURN_INDICATOR_LEFT=2
+int64 TURN_INDICATOR_RIGHT=3
+int64 TURN_INDICATOR_HAZARD=4
+
+int64 LIGHT_UNKNOWN=0
+int64 LIGHT_OFF=1
+int64 LIGHT_ON=2
 ###########################################################################################################################################################

--- a/perception_msgs/msg/HEXAMOTION.msg
+++ b/perception_msgs/msg/HEXAMOTION.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=17
 uint8 CONTINUOUS_STATE_SIZE=16
-uint8 DISCRETE_STATE_SIZE=0
+uint8 DISCRETE_STATE_SIZE=1
 
-#   The HEXAMOTION state model (N=16) has the following entries
+#   The HEXAMOTION state model (N=16 & M=1) has the following entries
 #   continuous_state:
 uint8 X=0             # x position of reference point in header frame [m]
 uint8 Y=1             # y position of reference point in header frame [m]
@@ -24,5 +24,12 @@ uint8 LENGTH=13       # length in object frame [m]
 uint8 WIDTH=14        # width in object frame [m]
 uint8 HEIGHT=15       # height in object frame [m]
 #   discrete_state:
-#   currently none
+uint8 TURN_INDICATOR=0  # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
+
+# discrete state enums
+uint8 TURN_INDICATOR_UNKNOWN=0
+uint8 TURN_INDICATOR_OFF=1
+uint8 TURN_INDICATOR_LEFT=2
+uint8 TURN_INDICATOR_RIGHT=3
+uint8 TURN_INDICATOR_HAZARD=4
 ###########################################################################################################################################################

--- a/perception_msgs/msg/HEXAMOTION.msg
+++ b/perception_msgs/msg/HEXAMOTION.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=17
 uint8 CONTINUOUS_STATE_SIZE=16
-uint8 DISCRETE_STATE_SIZE=1
+uint8 DISCRETE_STATE_SIZE=4
 
-#   The HEXAMOTION state model (N=16 & M=1) has the following entries
+#   The HEXAMOTION state model (N=16 & M=4) has the following entries
 #   continuous_state:
 uint8 X=0             # x position of reference point in header frame [m]
 uint8 Y=1             # y position of reference point in header frame [m]
@@ -25,11 +25,17 @@ uint8 WIDTH=14        # width in object frame [m]
 uint8 HEIGHT=15       # height in object frame [m]
 #   discrete_state:
 uint8 TURN_INDICATOR=0  # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
+uint8 BRAKE_LIGHT=2     # brake light state (0=unknown, 1=off, 2=on)
+uint8 REVERSE_LIGHT=3   # reverse light state (0=unknown, 1=off, 2=on)
 
 # discrete state enums
-uint8 TURN_INDICATOR_UNKNOWN=0
-uint8 TURN_INDICATOR_OFF=1
-uint8 TURN_INDICATOR_LEFT=2
-uint8 TURN_INDICATOR_RIGHT=3
-uint8 TURN_INDICATOR_HAZARD=4
+int64 TURN_INDICATOR_UNKNOWN=0
+int64 TURN_INDICATOR_OFF=1
+int64 TURN_INDICATOR_LEFT=2
+int64 TURN_INDICATOR_RIGHT=3
+int64 TURN_INDICATOR_HAZARD=4
+
+int64 LIGHT_UNKNOWN=0
+int64 LIGHT_OFF=1
+int64 LIGHT_ON=2
 ###########################################################################################################################################################

--- a/perception_msgs/msg/HEXAMOTION.msg
+++ b/perception_msgs/msg/HEXAMOTION.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=17
 uint8 CONTINUOUS_STATE_SIZE=16
-uint8 DISCRETE_STATE_SIZE=4
+uint8 DISCRETE_STATE_SIZE=3
 
-#   The HEXAMOTION state model (N=16 & M=4) has the following entries
+#   The HEXAMOTION state model (N=16 & M=3) has the following entries
 #   continuous_state:
 uint8 X=0             # x position of reference point in header frame [m]
 uint8 Y=1             # y position of reference point in header frame [m]
@@ -25,8 +25,8 @@ uint8 WIDTH=14        # width in object frame [m]
 uint8 HEIGHT=15       # height in object frame [m]
 #   discrete_state:
 uint8 TURN_INDICATOR=0  # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
-uint8 BRAKE_LIGHT=2     # brake light state (0=unknown, 1=off, 2=on)
-uint8 REVERSE_LIGHT=3   # reverse light state (0=unknown, 1=off, 2=on)
+uint8 BRAKE_LIGHT=1     # brake light state (0=unknown, 1=off, 2=on)
+uint8 REVERSE_LIGHT=2   # reverse light state (0=unknown, 1=off, 2=on)
 
 # discrete state enums
 int64 TURN_INDICATOR_UNKNOWN=0

--- a/perception_msgs/msg/ISCACTR.msg
+++ b/perception_msgs/msg/ISCACTR.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=16
 uint8 CONTINUOUS_STATE_SIZE=12
-uint8 DISCRETE_STATE_SIZE=1
+uint8 DISCRETE_STATE_SIZE=4
 
-#   The ISCACTR state model with extent (N=12 & M=1) has the following entries
+#   The ISCACTR state model with extent (N=12 & M=4) has the following entries
 #   continuous_state:
 uint8 X=0          # x position of reference point in header frame [m]
 uint8 Y=1          # y position of reference point in header frame [m]
@@ -21,11 +21,17 @@ uint8 LENGTH=10    # length in object frame [m]
 uint8 HEIGHT=11    # height in object frame [m]
 #   discrete_state:
 uint8 TURN_INDICATOR=0  # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
+uint8 BRAKE_LIGHT=2     # brake light state (0=unknown, 1=off, 2=on)
+uint8 REVERSE_LIGHT=3   # reverse light state (0=unknown, 1=off, 2=on)
 
 # discrete state enums
-uint8 TURN_INDICATOR_UNKNOWN=0
-uint8 TURN_INDICATOR_OFF=1
-uint8 TURN_INDICATOR_LEFT=2
-uint8 TURN_INDICATOR_RIGHT=3
-uint8 TURN_INDICATOR_HAZARD=4
+int64 TURN_INDICATOR_UNKNOWN=0
+int64 TURN_INDICATOR_OFF=1
+int64 TURN_INDICATOR_LEFT=2
+int64 TURN_INDICATOR_RIGHT=3
+int64 TURN_INDICATOR_HAZARD=4
+
+int64 LIGHT_UNKNOWN=0
+int64 LIGHT_OFF=1
+int64 LIGHT_ON=2
 ###########################################################################################################################################################

--- a/perception_msgs/msg/ISCACTR.msg
+++ b/perception_msgs/msg/ISCACTR.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=16
 uint8 CONTINUOUS_STATE_SIZE=12
-uint8 DISCRETE_STATE_SIZE=0
+uint8 DISCRETE_STATE_SIZE=1
 
-#   The ISCACTR state model with extent (N=12) has the following entries
+#   The ISCACTR state model with extent (N=12 & M=1) has the following entries
 #   continuous_state:
 uint8 X=0          # x position of reference point in header frame [m]
 uint8 Y=1          # y position of reference point in header frame [m]
@@ -20,5 +20,12 @@ uint8 WIDTH=9      # width in object frame [m]
 uint8 LENGTH=10    # length in object frame [m]
 uint8 HEIGHT=11    # height in object frame [m]
 #   discrete_state:
-#   currently none
+uint8 TURN_INDICATOR=0  # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
+
+# discrete state enums
+uint8 TURN_INDICATOR_UNKNOWN=0
+uint8 TURN_INDICATOR_OFF=1
+uint8 TURN_INDICATOR_LEFT=2
+uint8 TURN_INDICATOR_RIGHT=3
+uint8 TURN_INDICATOR_HAZARD=4
 ###########################################################################################################################################################

--- a/perception_msgs/msg/ISCACTR.msg
+++ b/perception_msgs/msg/ISCACTR.msg
@@ -3,9 +3,9 @@
 ###########################################################################################################################################################
 uint8 MODEL_ID=16
 uint8 CONTINUOUS_STATE_SIZE=12
-uint8 DISCRETE_STATE_SIZE=4
+uint8 DISCRETE_STATE_SIZE=3
 
-#   The ISCACTR state model with extent (N=12 & M=4) has the following entries
+#   The ISCACTR state model with extent (N=12 & M=3) has the following entries
 #   continuous_state:
 uint8 X=0          # x position of reference point in header frame [m]
 uint8 Y=1          # y position of reference point in header frame [m]
@@ -21,8 +21,8 @@ uint8 LENGTH=10    # length in object frame [m]
 uint8 HEIGHT=11    # height in object frame [m]
 #   discrete_state:
 uint8 TURN_INDICATOR=0  # turn indicator state (0=unknown, 1=off, 2=left, 3=right, 4=hazard)
-uint8 BRAKE_LIGHT=2     # brake light state (0=unknown, 1=off, 2=on)
-uint8 REVERSE_LIGHT=3   # reverse light state (0=unknown, 1=off, 2=on)
+uint8 BRAKE_LIGHT=1     # brake light state (0=unknown, 1=off, 2=on)
+uint8 REVERSE_LIGHT=2   # reverse light state (0=unknown, 1=off, 2=on)
 
 # discrete state enums
 int64 TURN_INDICATOR_UNKNOWN=0

--- a/perception_msgs_utils/include/perception_msgs_utils/impl/state_getters.h
+++ b/perception_msgs_utils/include/perception_msgs_utils/impl/state_getters.h
@@ -546,6 +546,52 @@ namespace object_access {
   }
 
   /**
+   * @brief Get the brake light state for a given object state.
+   *
+   * @param state
+   * @return uint8_t
+   */
+  inline uint8_t getBrakeLight(const ObjectState& state) {
+    sanityCheckDiscreteState(state);
+    return state.discrete_state[indexBrakeLight(state.model_id)];
+  }
+
+  /**
+   * @brief Get the brake light state for a given template object that contains an object state.
+   *
+   * @tparam T
+   * @param obj
+   * @return uint8_t
+   */
+  template <typename T>
+  inline uint8_t getBrakeLight(const T& obj) {
+    return getBrakeLight(obj.state);
+  }
+
+  /**
+   * @brief Get the reverse light state for a given object state.
+   *
+   * @param state
+   * @return uint8_t
+   */
+  inline uint8_t getReverseLight(const ObjectState& state) {
+    sanityCheckDiscreteState(state);
+    return state.discrete_state[indexReverseLight(state.model_id)];
+  }
+
+  /**
+   * @brief Get the reverse light state for a given template object that contains an object state.
+   *
+   * @tparam T
+   * @param obj
+   * @return uint8_t
+   */
+  template <typename T>
+  inline uint8_t getReverseLight(const T& obj) {
+    return getReverseLight(obj.state);
+  }
+
+  /**
    * @brief Get the traffic light state for a given object state.
    *
    * @param state

--- a/perception_msgs_utils/include/perception_msgs_utils/impl/state_getters.h
+++ b/perception_msgs_utils/include/perception_msgs_utils/impl/state_getters.h
@@ -523,6 +523,29 @@ namespace object_access {
   }
 
   /**
+   * @brief Get the turn indicator state for a given object state.
+   *
+   * @param state
+   * @return uint8_t
+   */
+  inline uint8_t getTurnIndicator(const ObjectState& state) {
+    sanityCheckDiscreteState(state);
+    return state.discrete_state[indexTurnIndicator(state.model_id)];
+  }
+
+  /**
+   * @brief Get the turn indicator state for a given template object that contains an object state.
+   *
+   * @tparam T
+   * @param obj
+   * @return uint8_t
+   */
+  template <typename T>
+  inline uint8_t getTurnIndicator(const T& obj) {
+    return getTurnIndicator(obj.state);
+  }
+
+  /**
    * @brief Get the traffic light state for a given object state.
    *
    * @param state

--- a/perception_msgs_utils/include/perception_msgs_utils/impl/state_index.h
+++ b/perception_msgs_utils/include/perception_msgs_utils/impl/state_index.h
@@ -428,6 +428,27 @@ namespace object_access {
   }
 
   /**
+   * @brief Get the vector-index that stores the turn indicator state for a given model-id.
+   *
+   * @param model_id
+   * @return int
+   */
+  inline int indexTurnIndicator(const unsigned char& model_id) {
+    switch(model_id) {
+      case EGO::MODEL_ID:
+        return EGO::TURN_INDICATOR;
+      case EGORWS::MODEL_ID:
+        return EGORWS::TURN_INDICATOR;
+      case ISCACTR::MODEL_ID:
+        return ISCACTR::TURN_INDICATOR;
+      case HEXAMOTION::MODEL_ID:
+        return HEXAMOTION::TURN_INDICATOR;
+      default:
+        throw std::invalid_argument(kExceptionUnknownStateEntry + std::to_string(model_id) + ", " + "turn_indicator");
+    }
+  }
+
+  /**
    * @brief Get the vector-index that stores the traffic light state for a given model-id.
    *
    * @param model_id
@@ -910,6 +931,28 @@ namespace object_access {
         return false;
       case HEXAMOTION::MODEL_ID:
         return false;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * @brief Indicates if given model contains a turn indicator state.
+   *
+   * @param model_id
+   * @return true
+   * @return false
+   */
+  inline bool hasTurnIndicator(const unsigned char& model_id) {
+    switch(model_id) {
+      case EGO::MODEL_ID:
+        return true;
+      case EGORWS::MODEL_ID:
+        return true;
+      case ISCACTR::MODEL_ID:
+        return true;
+      case HEXAMOTION::MODEL_ID:
+        return true;
       default:
         return false;
     }

--- a/perception_msgs_utils/include/perception_msgs_utils/impl/state_index.h
+++ b/perception_msgs_utils/include/perception_msgs_utils/impl/state_index.h
@@ -449,6 +449,48 @@ namespace object_access {
   }
 
   /**
+   * @brief Get the vector-index that stores the brake light state for a given model-id.
+   *
+   * @param model_id
+   * @return int
+   */
+  inline int indexBrakeLight(const unsigned char& model_id) {
+    switch(model_id) {
+      case EGO::MODEL_ID:
+        return EGO::BRAKE_LIGHT;
+      case EGORWS::MODEL_ID:
+        return EGORWS::BRAKE_LIGHT;
+      case ISCACTR::MODEL_ID:
+        return ISCACTR::BRAKE_LIGHT;
+      case HEXAMOTION::MODEL_ID:
+        return HEXAMOTION::BRAKE_LIGHT;
+      default:
+        throw std::invalid_argument(kExceptionUnknownStateEntry + std::to_string(model_id) + ", " + "brake_light");
+    }
+  }
+
+  /**
+   * @brief Get the vector-index that stores the reverse light state for a given model-id.
+   *
+   * @param model_id
+   * @return int
+   */
+  inline int indexReverseLight(const unsigned char& model_id) {
+    switch(model_id) {
+      case EGO::MODEL_ID:
+        return EGO::REVERSE_LIGHT;
+      case EGORWS::MODEL_ID:
+        return EGORWS::REVERSE_LIGHT;
+      case ISCACTR::MODEL_ID:
+        return ISCACTR::REVERSE_LIGHT;
+      case HEXAMOTION::MODEL_ID:
+        return HEXAMOTION::REVERSE_LIGHT;
+      default:
+        throw std::invalid_argument(kExceptionUnknownStateEntry + std::to_string(model_id) + ", " + "reverse_light");
+    }
+  }
+
+  /**
    * @brief Get the vector-index that stores the traffic light state for a given model-id.
    *
    * @param model_id
@@ -944,6 +986,50 @@ namespace object_access {
    * @return false
    */
   inline bool hasTurnIndicator(const unsigned char& model_id) {
+    switch(model_id) {
+      case EGO::MODEL_ID:
+        return true;
+      case EGORWS::MODEL_ID:
+        return true;
+      case ISCACTR::MODEL_ID:
+        return true;
+      case HEXAMOTION::MODEL_ID:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * @brief Indicates if given model contains a brake light state.
+   *
+   * @param model_id
+   * @return true
+   * @return false
+   */
+  inline bool hasBrakeLight(const unsigned char& model_id) {
+    switch(model_id) {
+      case EGO::MODEL_ID:
+        return true;
+      case EGORWS::MODEL_ID:
+        return true;
+      case ISCACTR::MODEL_ID:
+        return true;
+      case HEXAMOTION::MODEL_ID:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * @brief Indicates if given model contains a reverse light state.
+   *
+   * @param model_id
+   * @return true
+   * @return false
+   */
+  inline bool hasReverseLight(const unsigned char& model_id) {
     switch(model_id) {
       case EGO::MODEL_ID:
         return true;

--- a/perception_msgs_utils/include/perception_msgs_utils/impl/state_setters.h
+++ b/perception_msgs_utils/include/perception_msgs_utils/impl/state_setters.h
@@ -612,6 +612,30 @@ namespace object_access {
   }
 
   /**
+   * @brief Set the turn indicator for a given object state.
+   *
+   * @param state
+   * @param val
+   */
+  inline void setTurnIndicator(ObjectState& state, const uint8_t val) {
+    sanityCheckDiscreteState(state);
+    const int idx = indexTurnIndicator(state.model_id);
+    state.discrete_state[idx] = val;
+  }
+
+  /**
+   * @brief Set the turn indicator for a given template object that contains an object state.
+   *
+   * @tparam T
+   * @param obj
+   * @param val
+   */
+  template <typename T>
+  inline void setTurnIndicator(T& obj, const uint8_t val) {
+    setTurnIndicator(obj.state, val);
+  }
+
+  /**
    * @brief Set the traffic light state for a given object state.
    *
    * @param state

--- a/perception_msgs_utils/include/perception_msgs_utils/impl/state_setters.h
+++ b/perception_msgs_utils/include/perception_msgs_utils/impl/state_setters.h
@@ -636,6 +636,54 @@ namespace object_access {
   }
 
   /**
+   * @brief Set the brake light for a given object state.
+   *
+   * @param state
+   * @param val
+   */
+  inline void setBrakeLight(ObjectState& state, const uint8_t val) {
+    sanityCheckDiscreteState(state);
+    const int idx = indexBrakeLight(state.model_id);
+    state.discrete_state[idx] = val;
+  }
+
+  /**
+   * @brief Set the brake light for a given template object that contains an object state.
+   *
+   * @tparam T
+   * @param obj
+   * @param val
+   */
+  template <typename T>
+  inline void setBrakeLight(T& obj, const uint8_t val) {
+    setBrakeLight(obj.state, val);
+  }
+
+  /**
+   * @brief Set the reverse light for a given object state.
+   *
+   * @param state
+   * @param val
+   */
+  inline void setReverseLight(ObjectState& state, const uint8_t val) {
+    sanityCheckDiscreteState(state);
+    const int idx = indexReverseLight(state.model_id);
+    state.discrete_state[idx] = val;
+  }
+
+  /**
+   * @brief Set the reverse light for a given template object that contains an object state.
+   *
+   * @tparam T
+   * @param obj
+   * @param val
+   */
+  template <typename T>
+  inline void setReverseLight(T& obj, const uint8_t val) {
+    setReverseLight(obj.state, val);
+  }
+
+  /**
    * @brief Set the traffic light state for a given object state.
    *
    * @param state

--- a/perception_msgs_utils/src/perception_msgs_utils/state_getters.py
+++ b/perception_msgs_utils/src/perception_msgs_utils/state_getters.py
@@ -40,7 +40,7 @@ from .state_index import (
     index_steering_angle_ack, index_steering_angle_rate_ack,
     index_steering_angle_front, index_steering_angle_rear,
     index_width, index_length, index_height, index_standstill,
-    index_state, index_type
+    index_turn_indicator, index_state, index_type
 )
 from .checks import sanity_check_continuous_state, sanity_check_discrete_state
 
@@ -178,6 +178,12 @@ def get_standstill(obj: T) -> bool:
     state = obj if isinstance(obj, ObjectState) else obj.state
     sanity_check_discrete_state(state)
     return state.discrete_state[index_standstill(state.model_id)]
+
+def get_turn_indicator(obj: T) -> int:
+    """Get the turn indicator state for a given object or object state."""
+    state = obj if isinstance(obj, ObjectState) else obj.state
+    sanity_check_discrete_state(state)
+    return int(state.discrete_state[index_turn_indicator(state.model_id)])
 
 def get_state(obj: T) -> int:
     """Get the traffic light state for a given object or object state."""

--- a/perception_msgs_utils/src/perception_msgs_utils/state_getters.py
+++ b/perception_msgs_utils/src/perception_msgs_utils/state_getters.py
@@ -40,7 +40,8 @@ from .state_index import (
     index_steering_angle_ack, index_steering_angle_rate_ack,
     index_steering_angle_front, index_steering_angle_rear,
     index_width, index_length, index_height, index_standstill,
-    index_turn_indicator, index_state, index_type
+    index_turn_indicator, index_brake_light, index_reverse_light,
+    index_state, index_type
 )
 from .checks import sanity_check_continuous_state, sanity_check_discrete_state
 
@@ -184,6 +185,18 @@ def get_turn_indicator(obj: T) -> int:
     state = obj if isinstance(obj, ObjectState) else obj.state
     sanity_check_discrete_state(state)
     return int(state.discrete_state[index_turn_indicator(state.model_id)])
+
+def get_brake_light(obj: T) -> int:
+    """Get the brake light state for a given object or object state."""
+    state = obj if isinstance(obj, ObjectState) else obj.state
+    sanity_check_discrete_state(state)
+    return int(state.discrete_state[index_brake_light(state.model_id)])
+
+def get_reverse_light(obj: T) -> int:
+    """Get the reverse light state for a given object or object state."""
+    state = obj if isinstance(obj, ObjectState) else obj.state
+    sanity_check_discrete_state(state)
+    return int(state.discrete_state[index_reverse_light(state.model_id)])
 
 def get_state(obj: T) -> int:
     """Get the traffic light state for a given object or object state."""

--- a/perception_msgs_utils/src/perception_msgs_utils/state_index.py
+++ b/perception_msgs_utils/src/perception_msgs_utils/state_index.py
@@ -74,12 +74,16 @@ _EGORWS_INDICES = {
 
 _EGO_DISCRETE_INDICES = {
     'standstill': EGO.STANDSTILL,
-    'turn_indicator': EGO.TURN_INDICATOR
+    'turn_indicator': EGO.TURN_INDICATOR,
+    'brake_light': EGO.BRAKE_LIGHT,
+    'reverse_light': EGO.REVERSE_LIGHT
 }
 
 _EGORWS_DISCRETE_INDICES = {
     'standstill': EGORWS.STANDSTILL,
-    'turn_indicator': EGORWS.TURN_INDICATOR
+    'turn_indicator': EGORWS.TURN_INDICATOR,
+    'brake_light': EGORWS.BRAKE_LIGHT,
+    'reverse_light': EGORWS.REVERSE_LIGHT
 }
 
 _ISCACTR_INDICES = {
@@ -98,7 +102,9 @@ _ISCACTR_INDICES = {
 }
 
 _ISCACTR_DISCRETE_INDICES = {
-    'turn_indicator': ISCACTR.TURN_INDICATOR
+    'turn_indicator': ISCACTR.TURN_INDICATOR,
+    'brake_light': ISCACTR.BRAKE_LIGHT,
+    'reverse_light': ISCACTR.REVERSE_LIGHT
 }
 
 _HEXAMOTION_INDICES = {
@@ -121,7 +127,9 @@ _HEXAMOTION_INDICES = {
 }
 
 _HEXAMOTION_DISCRETE_INDICES = {
-    'turn_indicator': HEXAMOTION.TURN_INDICATOR
+    'turn_indicator': HEXAMOTION.TURN_INDICATOR,
+    'brake_light': HEXAMOTION.BRAKE_LIGHT,
+    'reverse_light': HEXAMOTION.REVERSE_LIGHT
 }
 
 _TRAFFICLIGHT_INDICES = {
@@ -303,6 +311,14 @@ def index_turn_indicator(model_id: int) -> int:
     """Get the vector-index that stores the turn indicator."""
     return _get_discrete_index(model_id, 'turn_indicator')
 
+def index_brake_light(model_id: int) -> int:
+    """Get the vector-index that stores the brake light."""
+    return _get_discrete_index(model_id, 'brake_light')
+
+def index_reverse_light(model_id: int) -> int:
+    """Get the vector-index that stores the reverse light."""
+    return _get_discrete_index(model_id, 'reverse_light')
+
 def index_state(model_id: int) -> int:
     """Get the vector-index that stores a state entry."""
     return _get_discrete_index(model_id, 'state')
@@ -398,6 +414,14 @@ def has_standstill(model_id: int) -> bool:
 def has_turn_indicator(model_id: int) -> bool:
     """Check if the model supports turn indicator."""
     return 'turn_indicator' in _DISCRETE_MODEL_CAPABILITIES.get(model_id, set())
+
+def has_brake_light(model_id: int) -> bool:
+    """Check if the model supports brake light."""
+    return 'brake_light' in _DISCRETE_MODEL_CAPABILITIES.get(model_id, set())
+
+def has_reverse_light(model_id: int) -> bool:
+    """Check if the model supports reverse light."""
+    return 'reverse_light' in _DISCRETE_MODEL_CAPABILITIES.get(model_id, set())
 
 def has_state(model_id: int) -> bool:
     """Check if the model supports state."""

--- a/perception_msgs_utils/src/perception_msgs_utils/state_index.py
+++ b/perception_msgs_utils/src/perception_msgs_utils/state_index.py
@@ -73,11 +73,13 @@ _EGORWS_INDICES = {
 }
 
 _EGO_DISCRETE_INDICES = {
-    'standstill': EGO.STANDSTILL
+    'standstill': EGO.STANDSTILL,
+    'turn_indicator': EGO.TURN_INDICATOR
 }
 
 _EGORWS_DISCRETE_INDICES = {
-    'standstill': EGORWS.STANDSTILL
+    'standstill': EGORWS.STANDSTILL,
+    'turn_indicator': EGORWS.TURN_INDICATOR
 }
 
 _ISCACTR_INDICES = {
@@ -93,6 +95,10 @@ _ISCACTR_INDICES = {
     'width': ISCACTR.WIDTH,
     'length': ISCACTR.LENGTH,
     'height': ISCACTR.HEIGHT
+}
+
+_ISCACTR_DISCRETE_INDICES = {
+    'turn_indicator': ISCACTR.TURN_INDICATOR
 }
 
 _HEXAMOTION_INDICES = {
@@ -112,6 +118,10 @@ _HEXAMOTION_INDICES = {
     'length': HEXAMOTION.LENGTH,
     'width': HEXAMOTION.WIDTH,
     'height': HEXAMOTION.HEIGHT
+}
+
+_HEXAMOTION_DISCRETE_INDICES = {
+    'turn_indicator': HEXAMOTION.TURN_INDICATOR
 }
 
 _TRAFFICLIGHT_INDICES = {
@@ -138,6 +148,8 @@ _MODEL_CAPABILITIES: Dict[int, Set[str]] = {
 _DISCRETE_MODEL_CAPABILITIES: Dict[int, Set[str]] = {
     EGO_MODEL_ID: set(_EGO_DISCRETE_INDICES.keys()),
     EGORWS_MODEL_ID: set(_EGORWS_DISCRETE_INDICES.keys()),
+    ISCACTR_MODEL_ID: set(_ISCACTR_DISCRETE_INDICES.keys()),
+    HEXAMOTION_MODEL_ID: set(_HEXAMOTION_DISCRETE_INDICES.keys()),
     TRAFFICLIGHT_MODEL_ID: set(_TRAFFICLIGHT_DISCRETE_INDICES.keys())
 }
 
@@ -189,6 +201,10 @@ def _get_discrete_index(model_id: int, entry: str) -> int:
         indices = _EGO_DISCRETE_INDICES
     elif model_id == EGORWS_MODEL_ID:
         indices = _EGORWS_DISCRETE_INDICES
+    elif model_id == ISCACTR_MODEL_ID:
+        indices = _ISCACTR_DISCRETE_INDICES
+    elif model_id == HEXAMOTION_MODEL_ID:
+        indices = _HEXAMOTION_DISCRETE_INDICES
     elif model_id == TRAFFICLIGHT_MODEL_ID:
         indices = _TRAFFICLIGHT_DISCRETE_INDICES
     else:
@@ -283,6 +299,10 @@ def index_standstill(model_id: int) -> int:
     """Get the vector-index that stores the standstill flag."""
     return _get_discrete_index(model_id, 'standstill')
 
+def index_turn_indicator(model_id: int) -> int:
+    """Get the vector-index that stores the turn indicator."""
+    return _get_discrete_index(model_id, 'turn_indicator')
+
 def index_state(model_id: int) -> int:
     """Get the vector-index that stores a state entry."""
     return _get_discrete_index(model_id, 'state')
@@ -374,6 +394,10 @@ def has_height(model_id: int) -> bool:
 def has_standstill(model_id: int) -> bool:
     """Check if the model supports standstill."""
     return 'standstill' in _DISCRETE_MODEL_CAPABILITIES.get(model_id, set())
+
+def has_turn_indicator(model_id: int) -> bool:
+    """Check if the model supports turn indicator."""
+    return 'turn_indicator' in _DISCRETE_MODEL_CAPABILITIES.get(model_id, set())
 
 def has_state(model_id: int) -> bool:
     """Check if the model supports state."""

--- a/perception_msgs_utils/src/perception_msgs_utils/state_setters.py
+++ b/perception_msgs_utils/src/perception_msgs_utils/state_setters.py
@@ -40,7 +40,8 @@ from .state_index import (
     index_steering_angle_ack, index_steering_angle_rate_ack,
     index_steering_angle_front, index_steering_angle_rear,
     index_width, index_length, index_height, index_standstill,
-    index_turn_indicator, index_state, index_type
+    index_turn_indicator, index_brake_light, index_reverse_light,
+    index_state, index_type
 )
 from .checks import sanity_check_continuous_state, sanity_check_discrete_state
 from .utils import set_continuous_state_covariance_to_unknown_at
@@ -245,6 +246,20 @@ def set_turn_indicator(obj: T, val: int) -> None:
     state = obj if isinstance(obj, ObjectState) else obj.state
     sanity_check_discrete_state(state)
     idx = index_turn_indicator(state.model_id)
+    state.discrete_state[idx] = val
+
+def set_brake_light(obj: T, val: int) -> None:
+    """Set the brake light state for a given object or object state."""
+    state = obj if isinstance(obj, ObjectState) else obj.state
+    sanity_check_discrete_state(state)
+    idx = index_brake_light(state.model_id)
+    state.discrete_state[idx] = val
+
+def set_reverse_light(obj: T, val: int) -> None:
+    """Set the reverse light state for a given object or object state."""
+    state = obj if isinstance(obj, ObjectState) else obj.state
+    sanity_check_discrete_state(state)
+    idx = index_reverse_light(state.model_id)
     state.discrete_state[idx] = val
 
 def set_state(obj: T, val: int) -> None:

--- a/perception_msgs_utils/src/perception_msgs_utils/state_setters.py
+++ b/perception_msgs_utils/src/perception_msgs_utils/state_setters.py
@@ -40,7 +40,7 @@ from .state_index import (
     index_steering_angle_ack, index_steering_angle_rate_ack,
     index_steering_angle_front, index_steering_angle_rear,
     index_width, index_length, index_height, index_standstill,
-    index_state, index_type
+    index_turn_indicator, index_state, index_type
 )
 from .checks import sanity_check_continuous_state, sanity_check_discrete_state
 from .utils import set_continuous_state_covariance_to_unknown_at
@@ -238,6 +238,13 @@ def set_standstill(obj: T, val: bool) -> None:
     state = obj if isinstance(obj, ObjectState) else obj.state
     sanity_check_discrete_state(state)
     idx = index_standstill(state.model_id)
+    state.discrete_state[idx] = val
+
+def set_turn_indicator(obj: T, val: int) -> None:
+    """Set the turn indicator state for a given object or object state."""
+    state = obj if isinstance(obj, ObjectState) else obj.state
+    sanity_check_discrete_state(state)
+    idx = index_turn_indicator(state.model_id)
     state.discrete_state[idx] = val
 
 def set_state(obj: T, val: int) -> None:

--- a/perception_msgs_utils/test/impl/test_object_access.cpp
+++ b/perception_msgs_utils/test/impl/test_object_access.cpp
@@ -147,6 +147,14 @@ TEST(perception_msgs, test_set_get_EGO)
   setTurnIndicator(obj, EGO::TURN_INDICATOR_LEFT);
   EXPECT_EQ(EGO::TURN_INDICATOR_LEFT, getTurnIndicator(obj));
 
+  // set/getBrakeLight
+  setBrakeLight(obj, EGO::LIGHT_ON);
+  EXPECT_EQ(EGO::LIGHT_ON, getBrakeLight(obj));
+
+  // set/getReverseLight
+  setReverseLight(obj, EGO::LIGHT_OFF);
+  EXPECT_EQ(EGO::LIGHT_OFF, getReverseLight(obj));
+
   // unknown covariance after setting state values
   std::vector<double> continuous_state_covariance = getContinuousStateCovariance(obj);
   int n = getContinuousStateSize(obj);
@@ -241,6 +249,14 @@ TEST(perception_msgs, test_set_get_EGORWS)
   setTurnIndicator(obj, EGORWS::TURN_INDICATOR_RIGHT);
   EXPECT_EQ(EGORWS::TURN_INDICATOR_RIGHT, getTurnIndicator(obj));
 
+  // set/getBrakeLight
+  setBrakeLight(obj, EGORWS::LIGHT_OFF);
+  EXPECT_EQ(EGORWS::LIGHT_OFF, getBrakeLight(obj));
+
+  // set/getReverseLight
+  setReverseLight(obj, EGORWS::LIGHT_ON);
+  EXPECT_EQ(EGORWS::LIGHT_ON, getReverseLight(obj));
+
   // unknown covariance after setting state values
   std::vector<double> continuous_state_covariance = getContinuousStateCovariance(obj);
   int n = getContinuousStateSize(obj);
@@ -325,6 +341,14 @@ TEST(perception_msgs, test_set_get_ISCACTR)
   // set/getTurnIndicator
   setTurnIndicator(obj, ISCACTR::TURN_INDICATOR_OFF);
   EXPECT_EQ(ISCACTR::TURN_INDICATOR_OFF, getTurnIndicator(obj));
+
+  // set/getBrakeLight
+  setBrakeLight(obj, ISCACTR::LIGHT_ON);
+  EXPECT_EQ(ISCACTR::LIGHT_ON, getBrakeLight(obj));
+
+  // set/getReverseLight
+  setReverseLight(obj, ISCACTR::LIGHT_OFF);
+  EXPECT_EQ(ISCACTR::LIGHT_OFF, getReverseLight(obj));
 }
 
 TEST(perception_msgs, test_set_get_HEXAMOTION)
@@ -417,6 +441,14 @@ TEST(perception_msgs, test_set_get_HEXAMOTION)
   // set/getTurnIndicator
   setTurnIndicator(obj, HEXAMOTION::TURN_INDICATOR_HAZARD);
   EXPECT_EQ(HEXAMOTION::TURN_INDICATOR_HAZARD, getTurnIndicator(obj));
+
+  // set/getBrakeLight
+  setBrakeLight(obj, HEXAMOTION::LIGHT_OFF);
+  EXPECT_EQ(HEXAMOTION::LIGHT_OFF, getBrakeLight(obj));
+
+  // set/getReverseLight
+  setReverseLight(obj, HEXAMOTION::LIGHT_ON);
+  EXPECT_EQ(HEXAMOTION::LIGHT_ON, getReverseLight(obj));
 }
 
 TEST(perception_msgs, test_set_get_TRAFFICLIGHT)

--- a/perception_msgs_utils/test/impl/test_object_access.cpp
+++ b/perception_msgs_utils/test/impl/test_object_access.cpp
@@ -143,6 +143,10 @@ TEST(perception_msgs, test_set_get_EGO)
   setStandstill(obj, true);
   EXPECT_EQ(true, getStandstill(obj));
 
+  // set/getTurnIndicator
+  setTurnIndicator(obj, EGO::TURN_INDICATOR_LEFT);
+  EXPECT_EQ(EGO::TURN_INDICATOR_LEFT, getTurnIndicator(obj));
+
   // unknown covariance after setting state values
   std::vector<double> continuous_state_covariance = getContinuousStateCovariance(obj);
   int n = getContinuousStateSize(obj);
@@ -233,6 +237,10 @@ TEST(perception_msgs, test_set_get_EGORWS)
   setStandstill(obj, true);
   EXPECT_EQ(true, getStandstill(obj));
 
+  // set/getTurnIndicator
+  setTurnIndicator(obj, EGORWS::TURN_INDICATOR_RIGHT);
+  EXPECT_EQ(EGORWS::TURN_INDICATOR_RIGHT, getTurnIndicator(obj));
+
   // unknown covariance after setting state values
   std::vector<double> continuous_state_covariance = getContinuousStateCovariance(obj);
   int n = getContinuousStateSize(obj);
@@ -313,6 +321,10 @@ TEST(perception_msgs, test_set_get_ISCACTR)
   val = randomValue();
   setHeight(obj, val);
   EXPECT_DOUBLE_EQ(val, getHeight(obj));
+
+  // set/getTurnIndicator
+  setTurnIndicator(obj, ISCACTR::TURN_INDICATOR_OFF);
+  EXPECT_EQ(ISCACTR::TURN_INDICATOR_OFF, getTurnIndicator(obj));
 }
 
 TEST(perception_msgs, test_set_get_HEXAMOTION)
@@ -401,6 +413,10 @@ TEST(perception_msgs, test_set_get_HEXAMOTION)
   val = randomValue();
   setHeight(obj, val);
   EXPECT_DOUBLE_EQ(val, getHeight(obj));
+
+  // set/getTurnIndicator
+  setTurnIndicator(obj, HEXAMOTION::TURN_INDICATOR_HAZARD);
+  EXPECT_EQ(HEXAMOTION::TURN_INDICATOR_HAZARD, getTurnIndicator(obj));
 }
 
 TEST(perception_msgs, test_set_get_TRAFFICLIGHT)

--- a/perception_msgs_utils/test/test_object_access.py
+++ b/perception_msgs_utils/test/test_object_access.py
@@ -32,8 +32,8 @@ from perception_msgs_utils.init import initialize_state
 from perception_msgs_utils.utils import get_continuous_state_size, get_discrete_state_size, get_continuous_state_covariance_size
 from perception_msgs_utils.convenience_state_getters import get_continuous_state, get_discrete_state, get_continuous_state_covariance, get_class_with_highest_probability, get_pose_with_covariance, get_velocity, get_acceleration, get_roll_in_deg, get_pitch_in_deg, get_yaw_in_deg, get_velocity_xyz, get_velocity_magnitude, get_acceleration_magnitude, get_velocity_xyz_with_covariance, get_acceleration_xyz_with_covariance, get_acceleration_xyz
 from perception_msgs_utils.convenience_state_setters import set_continuous_state, set_discrete_state, set_continuous_state_covariance, set_continuous_state_covariance_at, set_pose_with_covariance_from_gm_pose_with_covariance, set_velocity_from_gm_vector3, set_acceleration_from_gm_vector3, set_roll_in_deg, set_pitch_in_deg, set_yaw_in_deg, set_velocity_xyz_yaw_from_gm_vector3, set_velocity_xyz_yaw_with_covariance_from_gm_vector3, set_acceleration_xyz_yaw_from_gm_vector3, set_acceleration_xyz_yaw_with_covariance_from_gm_vector3
-from perception_msgs_utils.state_setters import set_x, set_y, set_z, set_vel_lon, set_vel_lat, set_acc_lon, set_acc_lat, set_roll, set_pitch, set_yaw, set_yaw_rate, set_steering_angle_ack, set_steering_angle_rate_ack, set_standstill, set_turn_indicator, set_steering_angle_front, set_steering_angle_rear, set_width, set_length, set_height, set_roll_rate, set_pitch_rate, set_state, set_type
-from perception_msgs_utils.state_getters import get_x, get_y, get_z, get_vel_lon, get_vel_lat, get_acc_lon, get_acc_lat, get_roll, get_pitch, get_yaw, get_yaw_rate, get_steering_angle_ack, get_steering_angle_rate_ack, get_standstill, get_turn_indicator, get_steering_angle_front, get_steering_angle_rear, get_width, get_length, get_height, get_roll_rate, get_pitch_rate, get_state, get_type
+from perception_msgs_utils.state_setters import set_x, set_y, set_z, set_vel_lon, set_vel_lat, set_acc_lon, set_acc_lat, set_roll, set_pitch, set_yaw, set_yaw_rate, set_steering_angle_ack, set_steering_angle_rate_ack, set_standstill, set_turn_indicator, set_brake_light, set_reverse_light, set_steering_angle_front, set_steering_angle_rear, set_width, set_length, set_height, set_roll_rate, set_pitch_rate, set_state, set_type
+from perception_msgs_utils.state_getters import get_x, get_y, get_z, get_vel_lon, get_vel_lat, get_acc_lon, get_acc_lat, get_roll, get_pitch, get_yaw, get_yaw_rate, get_steering_angle_ack, get_steering_angle_rate_ack, get_standstill, get_turn_indicator, get_brake_light, get_reverse_light, get_steering_angle_front, get_steering_angle_rear, get_width, get_length, get_height, get_roll_rate, get_pitch_rate, get_state, get_type
 from perception_msgs_utils.state_index import index_vel_lon, index_vel_lat, index_acc_lon, index_acc_lat
 
 def random_value():
@@ -128,6 +128,12 @@ def test_set_get_EGO():
     set_turn_indicator(obj, EGO.TURN_INDICATOR_LEFT)
     assert get_turn_indicator(obj) == EGO.TURN_INDICATOR_LEFT
 
+    set_brake_light(obj, EGO.LIGHT_ON)
+    assert get_brake_light(obj) == EGO.LIGHT_ON
+
+    set_reverse_light(obj, EGO.LIGHT_OFF)
+    assert get_reverse_light(obj) == EGO.LIGHT_OFF
+
     continuous_state_covariance = get_continuous_state_covariance(obj)
     n = get_continuous_state_size(obj)
     for i in range(n):
@@ -199,6 +205,12 @@ def test_set_get_EGORWS():
     set_turn_indicator(obj, EGORWS.TURN_INDICATOR_RIGHT)
     assert get_turn_indicator(obj) == EGORWS.TURN_INDICATOR_RIGHT
 
+    set_brake_light(obj, EGORWS.LIGHT_OFF)
+    assert get_brake_light(obj) == EGORWS.LIGHT_OFF
+
+    set_reverse_light(obj, EGORWS.LIGHT_ON)
+    assert get_reverse_light(obj) == EGORWS.LIGHT_ON
+
     continuous_state_covariance = get_continuous_state_covariance(obj)
     n = get_continuous_state_size(obj)
     for i in range(n):
@@ -262,6 +274,12 @@ def test_set_get_ISCACTR():
 
     set_turn_indicator(obj, ISCACTR.TURN_INDICATOR_OFF)
     assert get_turn_indicator(obj) == ISCACTR.TURN_INDICATOR_OFF
+
+    set_brake_light(obj, ISCACTR.LIGHT_ON)
+    assert get_brake_light(obj) == ISCACTR.LIGHT_ON
+
+    set_reverse_light(obj, ISCACTR.LIGHT_OFF)
+    assert get_reverse_light(obj) == ISCACTR.LIGHT_OFF
 
 def test_set_get_HEXAMOTION():
     obj = Object()
@@ -333,6 +351,12 @@ def test_set_get_HEXAMOTION():
 
     set_turn_indicator(obj, HEXAMOTION.TURN_INDICATOR_HAZARD)
     assert get_turn_indicator(obj) == HEXAMOTION.TURN_INDICATOR_HAZARD
+
+    set_brake_light(obj, HEXAMOTION.LIGHT_OFF)
+    assert get_brake_light(obj) == HEXAMOTION.LIGHT_OFF
+
+    set_reverse_light(obj, HEXAMOTION.LIGHT_ON)
+    assert get_reverse_light(obj) == HEXAMOTION.LIGHT_ON
 
 def test_set_get_TRAFFICLIGHT():
     obj = Object()

--- a/perception_msgs_utils/test/test_object_access.py
+++ b/perception_msgs_utils/test/test_object_access.py
@@ -32,8 +32,8 @@ from perception_msgs_utils.init import initialize_state
 from perception_msgs_utils.utils import get_continuous_state_size, get_discrete_state_size, get_continuous_state_covariance_size
 from perception_msgs_utils.convenience_state_getters import get_continuous_state, get_discrete_state, get_continuous_state_covariance, get_class_with_highest_probability, get_pose_with_covariance, get_velocity, get_acceleration, get_roll_in_deg, get_pitch_in_deg, get_yaw_in_deg, get_velocity_xyz, get_velocity_magnitude, get_acceleration_magnitude, get_velocity_xyz_with_covariance, get_acceleration_xyz_with_covariance, get_acceleration_xyz
 from perception_msgs_utils.convenience_state_setters import set_continuous_state, set_discrete_state, set_continuous_state_covariance, set_continuous_state_covariance_at, set_pose_with_covariance_from_gm_pose_with_covariance, set_velocity_from_gm_vector3, set_acceleration_from_gm_vector3, set_roll_in_deg, set_pitch_in_deg, set_yaw_in_deg, set_velocity_xyz_yaw_from_gm_vector3, set_velocity_xyz_yaw_with_covariance_from_gm_vector3, set_acceleration_xyz_yaw_from_gm_vector3, set_acceleration_xyz_yaw_with_covariance_from_gm_vector3
-from perception_msgs_utils.state_setters import set_x, set_y, set_z, set_vel_lon, set_vel_lat, set_acc_lon, set_acc_lat, set_roll, set_pitch, set_yaw, set_yaw_rate, set_steering_angle_ack, set_steering_angle_rate_ack, set_standstill, set_steering_angle_front, set_steering_angle_rear, set_width, set_length, set_height, set_roll_rate, set_pitch_rate, set_state, set_type
-from perception_msgs_utils.state_getters import get_x, get_y, get_z, get_vel_lon, get_vel_lat, get_acc_lon, get_acc_lat, get_roll, get_pitch, get_yaw, get_yaw_rate, get_steering_angle_ack, get_steering_angle_rate_ack, get_standstill, get_steering_angle_front, get_steering_angle_rear, get_width, get_length, get_height, get_roll_rate, get_pitch_rate, get_state, get_type
+from perception_msgs_utils.state_setters import set_x, set_y, set_z, set_vel_lon, set_vel_lat, set_acc_lon, set_acc_lat, set_roll, set_pitch, set_yaw, set_yaw_rate, set_steering_angle_ack, set_steering_angle_rate_ack, set_standstill, set_turn_indicator, set_steering_angle_front, set_steering_angle_rear, set_width, set_length, set_height, set_roll_rate, set_pitch_rate, set_state, set_type
+from perception_msgs_utils.state_getters import get_x, get_y, get_z, get_vel_lon, get_vel_lat, get_acc_lon, get_acc_lat, get_roll, get_pitch, get_yaw, get_yaw_rate, get_steering_angle_ack, get_steering_angle_rate_ack, get_standstill, get_turn_indicator, get_steering_angle_front, get_steering_angle_rear, get_width, get_length, get_height, get_roll_rate, get_pitch_rate, get_state, get_type
 from perception_msgs_utils.state_index import index_vel_lon, index_vel_lat, index_acc_lon, index_acc_lat
 
 def random_value():
@@ -125,6 +125,9 @@ def test_set_get_EGO():
     set_standstill(obj, True)
     assert get_standstill(obj) == True
 
+    set_turn_indicator(obj, EGO.TURN_INDICATOR_LEFT)
+    assert get_turn_indicator(obj) == EGO.TURN_INDICATOR_LEFT
+
     continuous_state_covariance = get_continuous_state_covariance(obj)
     n = get_continuous_state_size(obj)
     for i in range(n):
@@ -193,6 +196,9 @@ def test_set_get_EGORWS():
     set_standstill(obj, True)
     assert get_standstill(obj) == True
 
+    set_turn_indicator(obj, EGORWS.TURN_INDICATOR_RIGHT)
+    assert get_turn_indicator(obj) == EGORWS.TURN_INDICATOR_RIGHT
+
     continuous_state_covariance = get_continuous_state_covariance(obj)
     n = get_continuous_state_size(obj)
     for i in range(n):
@@ -253,6 +259,9 @@ def test_set_get_ISCACTR():
     val = random_value()
     set_height(obj, val)
     assert get_height(obj) == pytest.approx(val)
+
+    set_turn_indicator(obj, ISCACTR.TURN_INDICATOR_OFF)
+    assert get_turn_indicator(obj) == ISCACTR.TURN_INDICATOR_OFF
 
 def test_set_get_HEXAMOTION():
     obj = Object()
@@ -321,6 +330,9 @@ def test_set_get_HEXAMOTION():
     val = random_value()
     set_height(obj, val)
     assert get_height(obj) == pytest.approx(val)
+
+    set_turn_indicator(obj, HEXAMOTION.TURN_INDICATOR_HAZARD)
+    assert get_turn_indicator(obj) == HEXAMOTION.TURN_INDICATOR_HAZARD
 
 def test_set_get_TRAFFICLIGHT():
     obj = Object()


### PR DESCRIPTION
- added a discrete states `TURN_INDICATOR`, `BRAKE_LIGHT`, `REVERSE_LIGHT` to all four state models (`EGO`, `EGORWS`, `ISCACTR`, `HEXAMOTION`)
- turn indicator is an `int64`: 0=unknown, 1=off, 2=left, 3=right, 4=hazard
- brake light is an `int64`: 0=unknown, 1=off, 2=on
- reverse light is an `int64`: 0=unknown, 1=off, 2=on
- also added access functions (cpp, py) incl. tests