### PR TITLE
Use frame-id of `EgoData` message in `getFrameId` for `EgoData`

### DIFF
--- a/tf2_perception_msgs/include/tf2_perception_msgs/impl/tf2_perception_msgs.h
+++ b/tf2_perception_msgs/include/tf2_perception_msgs/impl/tf2_perception_msgs.h
@@ -140,6 +140,6 @@ namespace tf2 {
   }
   template <>
   inline TF2_PERCEPTION_MSGS_FRAME_TYPE getFrameId(const EgoData& ego) {
-    return ego.state.header.frame_id;
+    return ego.header.frame_id;
   }
 }


### PR DESCRIPTION
`getFrameId` and `getTimestamp` were previously implemented inconsistently, as we used the timestamp of the `EgoData.header` field but the `frame_id` from the `state.header` field.

In addition, an unset `state.header` in a message caused `transform` calls to fail.